### PR TITLE
fix module import

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { AnyAction, Dispatch } from "redux";
 export declare const DispatchContext: React.Context<any>;
 export declare function useDipatch<A extends AnyAction = AnyAction>(): Dispatch<A>;


### PR DESCRIPTION
In `index.d.ts`, This way of importing React module may cause Error in TypeScript environment.